### PR TITLE
test: fix silly error output from incorrect test

### DIFF
--- a/cmd/oaas/handler_build_test.go
+++ b/cmd/oaas/handler_build_test.go
@@ -147,12 +147,15 @@ echo "fake-build-result" > %[1]s/build/output/image/disk.img
 }
 
 func TestBuildErrorsForMultipleBuilds(t *testing.T) {
-	restore := main.MockOsbuildBinary(t, `#!/bin/sh
-`)
-	defer restore()
-
-	baseURL, _, loggerHook := runTestServer(t)
+	baseURL, buildDir, loggerHook := runTestServer(t)
 	endpoint := baseURL + "api/v1/build"
+
+	restore := main.MockOsbuildBinary(t, fmt.Sprintf(`#!/bin/sh
+
+mkdir -p %[1]s/build/output/image
+echo "fake-build-result" > %[1]s/build/output/image/disk.img
+`, buildDir))
+	defer restore()
 
 	buf := makeTestPost(t, `{"exports": ["tree"]}`, `{"fake": "manifest"}`)
 	rsp, err := http.Post(endpoint, "application/x-tar", buf)


### PR DESCRIPTION
The TestBuildErrorsForMultipleBuilds woudl now give strange errors like:
```
ERRO[0000] Failed creating result tarball: exit status 2
```
when run. The reason is that the mocking is incomplete and did not create a result dir. However the new `tar` functionality is expecting this. This commit fixes this.